### PR TITLE
security: if buggy code throws a falsy value, convert it to an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,13 @@ async function handleResult(method, path, fn, args, res, next) {
             return;
         }
         // otherwise expect that the middleware should call next()
-    } catch (err) {
+    } catch (e) {
+        let err = e;
+        if (!err) {
+            let errType = typeof err;
+            err = new Error(`'${err}' (${errType}) was thrown`);
+        }
+
         let extra = '';
         if (method) {
             extra = ` '${method} ${path}'`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@root/async-router",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@root/async-router",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "devDependencies": {
         "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@root/async-router",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Write Express middleware and route handlers using async/await",
   "main": "lib/index.js",
   "homepage": "https://github.com/therootcompany/async-router",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "lint": "npx jshint@2 lib",
     "prettier": "npx prettier@2 --write **/*.{js,md}",
     "test": "npx jest@26 --runInBand --projects jest.config.json --forceExit",
-    "preversion": "npm test"
+    "preversion": "npm test",
+    "version": "npm version -m \"chore(release): bump to v%s\""
   },
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
It's possible for buggy code to `throw` a falsy value such as `undefined`, `0`, `false`, `null`, and `""`.

This casts falsy errors as errors so that `next(err)` will not continue further.